### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 The Sitemap MCP Server provides AI agents and MCP clients with powerful tools for fetching, parsing, analyzing, and visualizing website sitemaps. It handles all standard sitemap formats including XML, Google News, and plain text sitemaps.
 
+<a href="https://glama.ai/mcp/servers/@mugoosse/sitemap-mcp-server">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/@mugoosse/sitemap-mcp-server/badge" alt="Sitemap Server MCP server" />
+</a>
+
 ![License](https://img.shields.io/github/license/mugoosse/sitemap-mcp-server)
 ![PyPI](https://img.shields.io/pypi/v/sitemap-mcp-server)
 ![Python Version](https://img.shields.io/badge/python-3.11+-blue)


### PR DESCRIPTION
This PR adds a badge for the [Sitemap MCP Server](https://glama.ai/mcp/servers/@mugoosse/sitemap-mcp-server) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/@mugoosse/sitemap-mcp-server">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/@mugoosse/sitemap-mcp-server/badge" alt="Sitemap Server MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly assess that the MCP server is safe, server capabilities, and instructions for installing the server.